### PR TITLE
added nonfungible tokens support to migration rpc

### DIFF
--- a/src/cc/CCinclude.h
+++ b/src/cc/CCinclude.h
@@ -198,12 +198,12 @@ bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx);
 
 CScript EncodeTokenCreateOpRet(uint8_t funcid, std::vector<uint8_t> origpubkey, std::string name, std::string description, vscript_t vopretNonfungible);
 CScript EncodeTokenCreateOpRet(uint8_t funcid, std::vector<uint8_t> origpubkey, std::string name, std::string description, std::vector<std::pair<uint8_t, vscript_t>> oprets);
-CScript EncodeTokenImportOpRet(std::vector<uint8_t> origpubkey, std::string name, std::string description, uint256 srctokenid, std::vector<std::pair<uint8_t, vscript_t>> oprets);
+//CScript EncodeTokenImportOpRet(std::vector<uint8_t> origpubkey, std::string name, std::string description, uint256 srctokenid, std::vector<std::pair<uint8_t, vscript_t>> oprets);
 CScript EncodeTokenOpRet(uint256 tokenid, std::vector<CPubKey> voutPubkeys, std::pair<uint8_t, vscript_t> opretWithId);
 CScript EncodeTokenOpRet(uint256 tokenid, std::vector<CPubKey> voutPubkeys, std::vector<std::pair<uint8_t, vscript_t>> oprets);
 uint8_t DecodeTokenCreateOpRet(const CScript &scriptPubKey, std::vector<uint8_t> &origpubkey, std::string &name, std::string &description);
 uint8_t DecodeTokenCreateOpRet(const CScript &scriptPubKey, std::vector<uint8_t> &origpubkey, std::string &name, std::string &description, std::vector<std::pair<uint8_t, vscript_t>>  &oprets);
-uint8_t DecodeTokenImportOpRet(const CScript &scriptPubKey, std::vector<uint8_t> &origpubkey, std::string &name, std::string &description, uint256 &srctokenid, std::vector<std::pair<uint8_t, vscript_t>>  &oprets);
+//uint8_t DecodeTokenImportOpRet(const CScript &scriptPubKey, std::vector<uint8_t> &origpubkey, std::string &name, std::string &description, uint256 &srctokenid, std::vector<std::pair<uint8_t, vscript_t>>  &oprets);
 uint8_t DecodeTokenOpRet(const CScript scriptPubKey, uint8_t &evalCodeTokens, uint256 &tokenid, std::vector<CPubKey> &voutPubkeys, std::vector<std::pair<uint8_t, vscript_t>>  &oprets);
 void GetNonfungibleData(uint256 tokenid, vscript_t &vopretNonfungible);
 bool ExtractTokensCCVinPubkeys(const CTransaction &tx, std::vector<CPubKey> &vinPubkeys);
@@ -285,6 +285,8 @@ void vcalc_sha256(char deprecated[(256 >> 3) * 2 + 1],uint8_t hash[256 >> 3],uin
 bits256 bits256_doublesha256(char *deprecated,uint8_t *data,int32_t datalen);
 UniValue ValueFromAmount(const CAmount& amount);
 
+int64_t TotalPubkeyNormalInputs(const CTransaction &tx, const CPubKey &pubkey);
+int64_t TotalPubkeyCCInputs(const CTransaction &tx, const CPubKey &pubkey);
 
 // bitcoin LogPrintStr with category "-debug" cmdarg support for C++ ostringstream:
 #define CCLOG_INFO   0

--- a/src/cc/CCtokens.h
+++ b/src/cc/CCtokens.h
@@ -32,6 +32,7 @@ std::string CreateToken(int64_t txfee, int64_t assetsupply, std::string name, st
 std::string TokenTransfer(int64_t txfee, uint256 assetid, std::vector<uint8_t> destpubkey, int64_t total);
 int64_t HasBurnedTokensvouts(struct CCcontract_info *cp, Eval* eval, const CTransaction& tx, uint256 reftokenid);
 CPubKey GetTokenOriginatorPubKey(CScript scriptPubKey);
+bool IsTokenMarkerVout(CTxOut vout);
 
 int64_t GetTokenBalance(CPubKey pk, uint256 tokenid);
 UniValue TokenInfo(uint256 tokenid);

--- a/src/cc/CCtokensOpRet.cpp
+++ b/src/cc/CCtokensOpRet.cpp
@@ -44,6 +44,7 @@ CScript EncodeTokenCreateOpRet(uint8_t funcid, std::vector<uint8_t> origpubkey, 
     return(opret);
 }
 
+/*
 // opret 'i' for imported tokens
 CScript EncodeTokenImportOpRet(std::vector<uint8_t> origpubkey, std::string name, std::string description, uint256 srctokenid, std::vector<std::pair<uint8_t, vscript_t>> oprets)
 {
@@ -62,7 +63,7 @@ CScript EncodeTokenImportOpRet(std::vector<uint8_t> origpubkey, std::string name
     });
     return(opret);
 }
-
+*/
 
 
 CScript EncodeTokenOpRet(uint256 tokenid, std::vector<CPubKey> voutPubkeys, std::pair<uint8_t, vscript_t> opretWithId)
@@ -158,6 +159,7 @@ uint8_t DecodeTokenCreateOpRet(const CScript &scriptPubKey, std::vector<uint8_t>
     return (uint8_t)0;
 }
 
+/*
 // for imported tokens
 uint8_t DecodeTokenImportOpRet(const CScript &scriptPubKey, std::vector<uint8_t> &origpubkey, std::string &name, std::string &description, uint256 &srctokenid, std::vector<std::pair<uint8_t, vscript_t>>  &oprets)
 {
@@ -185,6 +187,7 @@ uint8_t DecodeTokenImportOpRet(const CScript &scriptPubKey, std::vector<uint8_t>
     LOGSTREAM((char *)"cctokens", CCLOG_INFO, stream << "DecodeTokenImportOpRet() incorrect token import opret" << std::endl);
     return (uint8_t)0;
 }
+*/
 
 // decodes token opret: 
 // for 't' returns all data from opret, vopretExtra contains other contract's data (currently only assets'). 
@@ -223,8 +226,8 @@ uint8_t DecodeTokenOpRet(const CScript scriptPubKey, uint8_t &evalCodeTokens, ui
         {
         case 'c':
             return DecodeTokenCreateOpRet(scriptPubKey, dummyPubkey, dummyName, dummyDescription, oprets);
-        case 'i':
-            return DecodeTokenImportOpRet(scriptPubKey, dummyPubkey, dummyName, dummyDescription, dummySrcTokenId, oprets);
+        //case 'i':
+        //    return DecodeTokenImportOpRet(scriptPubKey, dummyPubkey, dummyName, dummyDescription, dummySrcTokenId, oprets);
             //break;
         case 't':
            

--- a/src/importcoin.cpp
+++ b/src/importcoin.cpp
@@ -24,21 +24,71 @@
 #include "script/sign.h"
 #include "wallet/wallet.h"
 
+#include "cc/CCinclude.h"
+
 int32_t komodo_nextheight();
 
+// makes import tx for either coins or tokens
 CTransaction MakeImportCoinTransaction(const ImportProof &proof, const CTransaction &burnTx, const std::vector<CTxOut> &payouts, uint32_t nExpiryHeightOverride)
+{
+    //std::vector<uint8_t> payload = E_MARSHAL(ss << EVAL_IMPORTCOIN);
+    CScript scriptSig;
+
+    CMutableTransaction mtx = CreateNewContextualCMutableTransaction(Params().GetConsensus(), komodo_nextheight());
+    if (mtx.fOverwintered) 
+        mtx.nExpiryHeight = 0;
+    mtx.vout = payouts;
+    if (mtx.vout.size() == 0)
+        return CTransaction(mtx);
+
+    // add special import tx vin:
+    scriptSig << E_MARSHAL(ss << EVAL_IMPORTCOIN);      // simple payload for coins
+    mtx.vin.push_back(CTxIn(COutPoint(burnTx.GetHash(), 10e8), scriptSig));
+
+    if (nExpiryHeightOverride != 0)
+        mtx.nExpiryHeight = nExpiryHeightOverride;  //this is for validation code, to make a tx used for validating the import tx
+
+    auto importData = E_MARSHAL(ss << EVAL_IMPORTCOIN; ss << proof; ss << burnTx);  // added evalcode to differentiate importdata from token opret
+    // if it is tokens:
+    vscript_t vopret;
+    GetOpReturnData(mtx.vout.back().scriptPubKey, vopret);
+
+    if (!vopret.empty()) {
+        std::vector<uint8_t> vorigpubkey;
+        uint8_t funcId;
+        std::vector <std::pair<uint8_t, vscript_t>> oprets;
+        std::string name, desc;
+
+        if (DecodeTokenCreateOpRet(mtx.vout.back().scriptPubKey, vorigpubkey, name, desc, oprets) == 'c') {    // parse token 'c' opret
+            mtx.vout.pop_back(); //remove old token opret
+            oprets.push_back(std::make_pair(OPRETID_IMPORTDATA, importData));
+            mtx.vout.push_back(CTxOut(0, EncodeTokenCreateOpRet('c', vorigpubkey, name, desc, oprets)));   // make new token 'c' opret with importData                                                                                    
+        }
+        else {
+            LOGSTREAM("importcoin", CCLOG_INFO, stream << "MakeImportCoinTransaction() incorrect token import opret" << std::endl);
+        }
+    }
+    else { //no opret in coin payouts
+        mtx.vout.push_back(CTxOut(0, CScript() << OP_RETURN << importData));     // import tx's opret now is in the vout's tail
+    }
+
+    return CTransaction(mtx);
+}
+
+// prev import tx (for compatibility), only coins
+CTransaction MakeImportCoinTransactionVout0(const ImportProof &proof, const CTransaction &burnTx, const std::vector<CTxOut> &payouts, uint32_t nExpiryHeightOverride)
 {
     std::vector<uint8_t> payload = E_MARSHAL(ss << EVAL_IMPORTCOIN);
     CMutableTransaction mtx = CreateNewContextualCMutableTransaction(Params().GetConsensus(), komodo_nextheight());
-    if (mtx.fOverwintered) 
+    if (mtx.fOverwintered)
         mtx.nExpiryHeight = 0;
     mtx.vin.push_back(CTxIn(COutPoint(burnTx.GetHash(), 10e8), CScript() << payload));
     mtx.vout = payouts;
     auto importData = E_MARSHAL(ss << proof; ss << burnTx);
     mtx.vout.insert(mtx.vout.begin(), CTxOut(0, CScript() << OP_RETURN << importData));
 
-	if (nExpiryHeightOverride != 0)
-		mtx.nExpiryHeight = nExpiryHeightOverride;  //this is for construction of the tx used for validating importtx
+    if (nExpiryHeightOverride != 0)
+        mtx.nExpiryHeight = nExpiryHeightOverride;  //this is for construction of the tx used for validating importtx
     return CTransaction(mtx);
 }
 
@@ -46,7 +96,8 @@ CTransaction MakeImportCoinTransaction(const ImportProof &proof, const CTransact
 CTxOut MakeBurnOutput(CAmount value, uint32_t targetCCid, const std::string &targetSymbol, const std::vector<CTxOut> &payouts, const std::vector<uint8_t> &rawproof)
 {
     std::vector<uint8_t> opret;
-    opret = E_MARSHAL(ss << VARINT(targetCCid);
+    opret = E_MARSHAL(ss << (uint8_t)EVAL_IMPORTCOIN;  // should mark burn opret to differentiate it from token opret
+                      ss << VARINT(targetCCid);
                       ss << targetSymbol;
                       ss << SerializeHash(payouts);
                       ss << rawproof);
@@ -56,25 +107,145 @@ CTxOut MakeBurnOutput(CAmount value, uint32_t targetCCid, const std::string &tar
 
 bool UnmarshalImportTx(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts)
 {
+    if (importTx.vout.size() < 1) 
+        return false;
+    
+    if (importTx.vin.size() != 1 || importTx.vin[0].scriptSig != (CScript() << E_MARSHAL(ss << EVAL_IMPORTCOIN))) {
+        LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalImportTx() incorrect import tx vin" << std::endl);
+        return false;
+    }
+
+    std::vector<uint8_t> vImportData;
+    GetOpReturnData(importTx.vout.back().scriptPubKey, vImportData);
+    if (vImportData.empty()) {
+        LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalImportTx() no opret" << std::endl);
+        return false;
+    }
+
+    if (vImportData.begin()[0] == EVAL_TOKENS) {          // if it is tokens
+        // get import data after token opret:
+        std::vector<std::pair<uint8_t, vscript_t>>  oprets;
+        std::vector<uint8_t> vorigpubkey;
+        std::string name, desc;
+
+        if (DecodeTokenCreateOpRet(importTx.vout.back().scriptPubKey, vorigpubkey, name, desc, oprets) == 0) {
+            LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalImportTx() could not decode token opret" << std::endl);
+            return false;
+        }
+
+        GetOpretBlob(oprets, OPRETID_IMPORTDATA, vImportData);  // fetch import data after token opret
+        for (std::vector<std::pair<uint8_t, vscript_t>>::const_iterator i = oprets.begin(); i != oprets.end(); i++)
+            if ((*i).first == OPRETID_IMPORTDATA) {
+                oprets.erase(i);            // remove import data from token opret to restore original payouts:
+                break;
+            }
+
+        payouts = std::vector<CTxOut>(importTx.vout.begin(), importTx.vout.end()-1);       //exclude opret with import data 
+        payouts.push_back(CTxOut(0, EncodeTokenCreateOpRet('c', vorigpubkey, name, desc, oprets)));   // make original payouts token opret (without import data)
+    }
+    else {
+        //payouts = std::vector<CTxOut>(importTx.vout.begin()+1, importTx.vout.end());   // see next
+        payouts = std::vector<CTxOut>(importTx.vout.begin(), importTx.vout.end() - 1);   // skip opret; and it is now in the back
+    }
+
+    uint8_t evalCode;
+    bool retcode = E_UNMARSHAL(vImportData, ss >> evalCode; ss >> proof; ss >> burnTx);
+    if (!retcode)
+        LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalImportTx() could not unmarshal import data" << std::endl);
+    return retcode;
+}
+
+// old format support, for old tx validation, for coins only
+bool UnmarshalImportTxOld(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts)
+{
     std::vector<uint8_t> vData;
+    TxProof txproof;
+
     GetOpReturnData(importTx.vout[0].scriptPubKey, vData);
     if (importTx.vout.size() < 1) return false;
-    payouts = std::vector<CTxOut>(importTx.vout.begin()+1, importTx.vout.end());
-    return importTx.vin.size() == 1 &&
-           importTx.vin[0].scriptSig == (CScript() << E_MARSHAL(ss << EVAL_IMPORTCOIN)) &&
-           E_UNMARSHAL(vData, ss >> proof; ss >> burnTx);
+    payouts = std::vector<CTxOut>(importTx.vout.begin() + 1, importTx.vout.end());
+    bool retcode = importTx.vin.size() == 1 &&
+        importTx.vin[0].scriptSig == (CScript() << E_MARSHAL(ss << EVAL_IMPORTCOIN)) &&
+        E_UNMARSHAL(vData, ss >> txproof; ss >> burnTx);
+
+    if (retcode)
+        proof = ImportProof(txproof);
+
+    return retcode;
+}
+
+// old import tx format support with opret in vout[0], for old tx validation, for coins only
+bool UnmarshalImportTxVout0(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts)
+{
+    std::vector<uint8_t> vData;
+
+    GetOpReturnData(importTx.vout[0].scriptPubKey, vData);
+    if (importTx.vout.size() < 1) 
+        return false;
+    payouts = std::vector<CTxOut>(importTx.vout.begin() + 1, importTx.vout.end());
+    bool retcode = importTx.vin.size() == 1 &&
+                   importTx.vin[0].scriptSig == (CScript() << E_MARSHAL(ss << EVAL_IMPORTCOIN)) &&
+                   E_UNMARSHAL(vData, ss >> proof; ss >> burnTx);
+
+    if( retcode )
+        LOGSTREAM("importcoin", CCLOG_DEBUG1, stream << "UnmarshalImportTxVout0() parsed old import tx opret" << std::endl);
+    return retcode;
 }
 
 
 bool UnmarshalBurnTx(const CTransaction &burnTx, std::string &targetSymbol, uint32_t *targetCCid, uint256 &payoutsHash,std::vector<uint8_t>&rawproof)
 {
+    std::vector<uint8_t> vburnOpret; uint32_t ccid = 0;
+    uint8_t evalCode;
+
+    if (burnTx.vout.size() == 0) 
+        return false;
+
+    GetOpReturnData(burnTx.vout.back().scriptPubKey, vburnOpret);
+    if (vburnOpret.empty()) {
+        LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalBurnTx() cannot unmarshal burn tx: empty burn opret" << std::endl);
+        return false;
+    }
+
+    if (vburnOpret.begin()[0] == EVAL_TOKENS) {      //if it is tokens
+        std::vector<std::pair<uint8_t, vscript_t>>  oprets;
+        uint256 tokenid;
+        uint8_t evalCodeInOpret;
+        std::vector<CPubKey> voutTokenPubkeys;
+
+        //skip token opret:
+        if (DecodeTokenOpRet(burnTx.vout.back().scriptPubKey, evalCodeInOpret, tokenid, voutTokenPubkeys, oprets) == 0)
+            return false;
+
+        GetOpretBlob(oprets, OPRETID_BURNDATA, vburnOpret);  // fetch burnOpret after token opret
+    }
+    if (vburnOpret.begin()[0] == EVAL_IMPORTCOIN) {
+        uint8_t evalCode;
+        return E_UNMARSHAL(vburnOpret,  ss >> evalCode;
+                                        ss >> VARINT(*targetCCid);
+                                        ss >> targetSymbol;
+                                        ss >> payoutsHash;
+                                        ss >> rawproof);
+    }
+    else {
+        LOGSTREAM("importcoin", CCLOG_INFO, stream << "UnmarshalBurnTx() invalid eval code in opret" << std::endl);
+        return false;
+    }
+}
+
+// old format support for compatibility (no eval code in opret)
+bool UnmarshalBurnTxOld(const CTransaction &burnTx, std::string &targetSymbol, uint32_t *targetCCid, uint256 &payoutsHash, std::vector<uint8_t>&rawproof)
+{
     std::vector<uint8_t> burnOpret; uint32_t ccid = 0;
     if (burnTx.vout.size() == 0) return false;
     GetOpReturnData(burnTx.vout.back().scriptPubKey, burnOpret);
-    return E_UNMARSHAL(burnOpret, ss >> VARINT(*targetCCid);
-                    ss >> targetSymbol;
-                    ss >> payoutsHash;
-                    ss >> rawproof);
+    bool retcode = E_UNMARSHAL(burnOpret,   ss >> VARINT(*targetCCid);
+                                            ss >> targetSymbol;
+                                            ss >> payoutsHash;
+                                            ss >> rawproof);
+    if( retcode )
+        LOGSTREAM("importcoin", CCLOG_DEBUG1, stream << "UnmarshalBurnTxOld() parsed old burn tx opret" << std::endl);
+    return retcode;
 }
 
 
@@ -86,12 +257,44 @@ CAmount GetCoinImportValue(const CTransaction &tx)
     ImportProof proof;
     CTransaction burnTx;
     std::vector<CTxOut> payouts;
-    if (UnmarshalImportTx(tx, proof, burnTx, payouts)) {
-        return burnTx.vout.size() ? burnTx.vout.back().nValue : 0;
+
+    bool isNewImportTx = false;
+    if ((isNewImportTx = UnmarshalImportTx(tx, proof, burnTx, payouts)) || UnmarshalImportTxVout0(tx, proof, burnTx, payouts)) {
+        if (burnTx.vout.size() > 0)  {
+            vscript_t vburnOpret;
+
+            GetOpReturnData(burnTx.vout.back().scriptPubKey, vburnOpret);
+            if (vburnOpret.empty()) {
+                LOGSTREAM("importcoin", CCLOG_INFO, stream << "GetCoinImportValue() empty burn opret" << std::endl);
+                return 0;
+            }
+
+            if (isNewImportTx && vburnOpret.begin()[0] == EVAL_TOKENS) {      //if it is tokens
+             
+             /* This code would not link because we are in a shared library with no most of cc modules
+                Assume we do not need this extended check for payouts because we could not have markers in them
+                and we do validate payouts outputs in eval::ImportCoin()
+                struct CCcontract_info *cpTokens, CCtokens_info;
+                cpTokens = CCinit(&CCtokens_info, EVAL_TOKENS);
+
+                CAmount ccOutput = 0;
+                for (auto v : payouts)
+                    if (v.scriptPubKey.IsPayToCryptoCondition() && CTxOut(v.nValue, v.scriptPubKey) != MakeCC1vout(EVAL_TOKENS, v.nValue, GetUnspendable(cpTokens, NULL)))  
+                        ccOutput += v.nValue;        */
+
+                CAmount ccOutput = 0;
+                for (auto v = payouts.begin() + 1; v != payouts.end() - 1; v ++)  // skip marker, exclude opret
+                    if ((*v).scriptPubKey.IsPayToCryptoCondition())  
+                        ccOutput += (*v).nValue;
+
+                return ccOutput;
+            }
+            else
+                return burnTx.vout.back().nValue;
+        }
     }
     return 0;
 }
-
 
 /*
  * CoinImport is different enough from normal script execution that it's not worth
@@ -110,7 +313,7 @@ bool VerifyCoinImport(const CScript& scriptSig, TransactionSignatureChecker& che
             return false;
         if (evalScript.size() == 0)
             return false;
-        if (evalScript.begin()[0] != EVAL_IMPORTCOIN)
+        if (evalScript.begin()[0] != EVAL_IMPORTCOIN)   
             return false;
         // Ok, all looks good so far...
         CC *cond = CCNewEval(evalScript);

--- a/src/importcoin.h
+++ b/src/importcoin.h
@@ -92,11 +92,15 @@ public:
 CAmount GetCoinImportValue(const CTransaction &tx);
 
 CTransaction MakeImportCoinTransaction(const ImportProof &proof, const CTransaction &burnTx, const std::vector<CTxOut> &payouts, uint32_t nExpiryHeightOverride = 0);
+CTransaction MakeImportCoinTransactionVout0(const ImportProof &proof, const CTransaction &burnTx, const std::vector<CTxOut> &payouts, uint32_t nExpiryHeightOverride = 0);
 
 CTxOut MakeBurnOutput(CAmount value, uint32_t targetCCid, const std::string &targetSymbol, const std::vector<CTxOut> &payouts, const std::vector<uint8_t> &rawproof);
 
-bool UnmarshalBurnTx(const CTransaction &burnTx, std::string &targetSymbol, uint32_t *targetCCid, uint256 &payoutsHash, std::vector<uint8_t> &rawproof);
-bool UnmarshalImportTx(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts);
+bool UnmarshalBurnTx(const CTransaction &burnTx, std::string &targetSymbol, uint32_t *targetCCid, uint256 &payoutsHash, std::vector<uint8_t> &rawproof);    // evalcode in opret
+bool UnmarshalBurnTxOld(const CTransaction &burnTx, std::string &targetSymbol, uint32_t *targetCCid, uint256 &payoutsHash, std::vector<uint8_t>&rawproof);  // no evalcode in opret
+bool UnmarshalImportTx(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts);       // new ImportProof and vout back
+//bool UnmarshalImportTxOld(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts);  // txproof
+bool UnmarshalImportTxVout0(const CTransaction &importTx, ImportProof &proof, CTransaction &burnTx, std::vector<CTxOut> &payouts);  // new ImportProof but vout0
 
 bool VerifyCoinImport(const CScript& scriptSig, TransactionSignatureChecker& checker, CValidationState &state);
 

--- a/src/rpc/crosschain.cpp
+++ b/src/rpc/crosschain.cpp
@@ -35,6 +35,8 @@
 #include "script/standard.h"
 
 #include "key_io.h"
+#include "cc/CCinclude.h"
+#include "cc/CCtokens.h"
 
 #include "merkleblock.h"
 
@@ -61,6 +63,7 @@ int32_t GetSelfimportProof(const CMutableTransaction &sourceMtx, CMutableTransac
 std::string MakeGatewaysImportTx(uint64_t txfee, uint256 bindtxid, int32_t height, std::string refcoin, std::vector<uint8_t> proof, std::string rawburntx, int32_t ivout, uint256 burntxid);
 void CheckBurnTxSource(uint256 burntxid, std::string &targetSymbol, uint32_t &targetCCid);
 int32_t ensure_CCrequirements(uint8_t evalcode);
+bool EnsureWalletIsAvailable(bool avoidException);
 
 UniValue assetchainproof(const UniValue& params, bool fHelp)
 {
@@ -184,7 +187,7 @@ UniValue migrate_converttoexport(const UniValue& params, bool fHelp)
             "If neccesary, the transaction should be funded using fundrawtransaction.\n"
             "Finally, the transaction should be signed using signrawtransaction\n"
             "The finished export transaction, plus the payouts, should be passed to "
-            "the \"migrate_createimporttransaction\" method on a KMD node to get the corresponding "
+            "the \"migrate_createimporttransaction\" method to get the corresponding "
             "import transaction.\n"
             );
 
@@ -240,23 +243,22 @@ UniValue migrate_createburntransaction(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     //uint8_t *ptr; 
     //uint8_t i; 
-    uint32_t ccid = ASSETCHAINS_CC;
+    uint32_t ccid = ASSETCHAINS_CC; 
     int64_t txfee = 10000;
 
     if (fHelp || params.size() != 3 && params.size() != 4)
         throw runtime_error(
             "migrate_createburntransaction dest_symbol dest_addr amount [tokenid]\n"
-            "\nCreates a burn transaction and payouts to make a cross-chain coin or non-fungible token transfer.\n"
+            "\nCreates a raw burn transaction to make a cross-chain coin or non-fungible token transfer.\n"
             "The parameters:\n"
-            "dest_symbol -  destination chain ac_name\n"
-            "dest_addr -   address on the destination chain where coins are to be sent or pubkey if tokens are to be sent\n"
-            "amount -      amount in coins to be burned on the source chain and sent to the destination address/pubkey on the destination chain, for tokens should be equal to 1\n"
-            "tokenid -     token id, if tokens are transferred (optional). Only non-fungible tokens are supported\n"
+            "dest_symbol   destination chain ac_name\n"
+            "dest_addr     address on the destination chain where coins are to be sent or pubkey if tokens are to be sent\n"
+            "amount        amount in coins to be burned on the source chain and sent to the destination address/pubkey on the destination chain, for tokens should be equal to 1\n"
+            "tokenid       token id, if tokens are transferred (optional). Only non-fungible tokens are supported\n"
             "\n"
-            "The created burn transaction should be sent using sendrawtransaction to the source chain\n"
-            "The hex representation of the burn transaction with the payouts should be also passed to "
-            "the \"migrate_createimporttransaction\" method on a KMD node to get the corresponding "
-            "import transaction.\n"
+            "The transaction should be sent using sendrawtransaction to the source chain\n"
+            "The finished burn transaction and payouts should be also passed to "
+            "the \"migrate_createimporttransaction\" method to get the corresponding import transaction.\n"
         );
 
     if (ASSETCHAINS_CC < KOMODO_FIRSTFUNGIBLEID)
@@ -264,16 +266,16 @@ UniValue migrate_createburntransaction(const UniValue& params, bool fHelp)
 
     if (ASSETCHAINS_SYMBOL[0] == 0)
         throw runtime_error("Must be called on assetchain");
-    
+
     // if -pubkey not set it sends change to null pubkey. 
     // we need a better way to return errors from this function!
-    if ( ensure_CCrequirements(225) < 0 )
+    if (ensure_CCrequirements(225) < 0)
         throw runtime_error("You need to set -pubkey, or run setpukbey RPC, or imports are disabled on this chain.");
 
-    //    vector<uint8_t> txData(ParseHexV(params[0], "argument 1"));
-    // CMutableTransaction tx;
-    //    if (!E_UNMARSHAL(txData, ss >> tx))
-    //        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+//    vector<uint8_t> txData(ParseHexV(params[0], "argument 1"));
+   // CMutableTransaction tx;
+//    if (!E_UNMARSHAL(txData, ss >> tx))
+//        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
     string targetSymbol = params[0].get_str();
     if (targetSymbol.size() == 0 || targetSymbol.size() > 32)
@@ -284,106 +286,211 @@ UniValue migrate_createburntransaction(const UniValue& params, bool fHelp)
 
     std::string dest_addr_or_pubkey = params[1].get_str();
 
-    CAmount burnAmount = (CAmount)(atof(params[2].get_str().c_str()) * COIN + 0.00000000499999);
+    CAmount burnAmount;
+    if(params.size() == 3)
+        burnAmount = (CAmount)( atof(params[2].get_str().c_str()) * COIN + 0.00000000499999 );
+    else
+        burnAmount = atoll(params[2].get_str().c_str());
 
-    //    for (int i = 0; i<tx.vout.size(); i++) burnAmount += tx.vout[i].nValue;
+//    for (int i = 0; i<tx.vout.size(); i++) burnAmount += tx.vout[i].nValue;
     if (burnAmount <= 0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Cannot export a negative or zero value.");
     if (burnAmount > 1000000LL * COIN)
         throw JSONRPCError(RPC_TYPE_ERROR, "Cannot export more than 1 million coins per export.");
 
     uint256 tokenid = zeroid;
-    if (params.size() == 4)
+    if( params.size() == 4 )
         tokenid = Parseuint256(params[3].get_str().c_str());
 
     // check non-fungible tokens amount
-    if (!tokenid.IsNull() && burnAmount != 1)
+    if( !tokenid.IsNull() && burnAmount != 1 )
         throw JSONRPCError(RPC_TYPE_ERROR, "For tokens amount should be equal to 1, only non-fungible tokens are supported.");
 
     CPubKey myPubKey = Mypubkey();
-    struct CCcontract_info *cpDummy, C;
-    cpDummy = CCinit(&C, EVAL_TOKENS);
+    struct CCcontract_info *cpTokens, C;
+    cpTokens = CCinit(&C, EVAL_TOKENS);
 
     CMutableTransaction mtx = CreateNewContextualCMutableTransaction(Params().GetConsensus(), komodo_nextheight());
-    int64_t inputs;
-    if ((inputs = AddNormalinputs(mtx, myPubKey, burnAmount + txfee, 60)) == 0) {
-        throw runtime_error("Cannot find normal inputs\n");
-    }
 
     CScript scriptPubKey;
-    if (tokenid == zeroid) {        // coins
+    const std::string chainSymbol(ASSETCHAINS_SYMBOL);
+    std::vector<uint8_t> rawproof; //(chainSymbol.begin(), chainSymbol.end());
+
+    if (tokenid.IsNull()) {        // coins
+        int64_t inputs;
+        if ((inputs = AddNormalinputs(mtx, myPubKey, burnAmount + txfee, 60)) == 0) {
+            throw runtime_error("Cannot find normal inputs\n");
+        }
+
         CTxDestination txdest = DecodeDestination(dest_addr_or_pubkey.c_str());
         scriptPubKey = GetScriptForDestination(txdest);
         if (!scriptPubKey.IsPayToPublicKeyHash()) {
             throw JSONRPCError(RPC_TYPE_ERROR, "Incorrect destination addr.");
         }
         mtx.vout.push_back(CTxOut(burnAmount, scriptPubKey));               // 'model' vout
+        ret.push_back(Pair("payouts", HexStr(E_MARSHAL(ss << mtx.vout))));  // save 'model' vout
+
+        rawproof = E_MARSHAL(ss << chainSymbol); // add src chain name 
+
+        CTxOut burnOut = MakeBurnOutput(burnAmount, ccid, targetSymbol, mtx.vout, rawproof);  //make opret with burned amount
+
+        mtx.vout.clear();               // remove 'model' vout
+
+        int64_t change = inputs - burnAmount;
+        if (change != 0)
+            mtx.vout.push_back(CTxOut(change, CScript() << ParseHex(HexStr(myPubKey)) << OP_CHECKSIG)); // make change here to prevent it from making in FinalizeCCtx
+
+        mtx.vout.push_back(burnOut);    // mtx now has only burned vout (that is, amount sent to OP_RETURN making it unspendable)
+        std::string exportTxHex = FinalizeCCTx(0, cpTokens, mtx, myPubKey, txfee, CScript());  // no change no opret
+
     }
     else {   // tokens
+        CTransaction tokenbasetx;
+        uint256 hashBlock;
+        vscript_t vopretNonfungible;
+        vscript_t vopretBurnData;
+        std::vector<uint8_t> vorigpubkey, vdestpubkey;
+        std::string name, description;
+        std::vector<std::pair<uint8_t, vscript_t>>  oprets;
 
-             //mtx.vout.push_back(MakeCC1vout(EVAL_TOKENS, assetsupply, mypk));
-             //mtx.vout.push_back(CTxOut(txfee, CScript() << ParseHex(cp->CChexstr) << OP_CHECKSIG));
-             //return(FinalizeCCTx(0, cp, mtx, mypk, txfee, EncodeTokenCreateOpRet('c', Mypubkey(), name, description)));
+        if (!myGetTransaction(tokenid, tokenbasetx, hashBlock))
+            throw runtime_error("Could not load token creation tx\n");
+
+        // check if it is non-fungible tx and get its second evalcode from non-fungible payload
+        if (tokenbasetx.vout.size() == 0)
+            throw runtime_error("No vouts in token tx\n");
+
+        if (DecodeTokenCreateOpRet(tokenbasetx.vout.back().scriptPubKey, vorigpubkey, name, description, oprets) != 'c')
+            throw runtime_error("Incorrect token creation tx\n");
+        GetOpretBlob(oprets, OPRETID_NONFUNGIBLEDATA, vopretNonfungible);
+        if (vopretNonfungible.empty())
+            throw runtime_error("No non-fungible token data\n");
+
+        uint8_t destEvalCode = vopretNonfungible.begin()[0];
+        vdestpubkey = ParseHex(dest_addr_or_pubkey);
+        CPubKey destPubKey = pubkey2pk(vdestpubkey);
+        if (!destPubKey.IsValid())
+            throw runtime_error("Invalid destination pubkey\n");
+
+        int64_t inputs;
+        if ((inputs = AddNormalinputs(mtx, myPubKey, txfee, 1)) == 0)
+            throw runtime_error("No normal input found for txfee\n");
+
+        if (AddTokenCCInputs(cpTokens, mtx, myPubKey, tokenid, burnAmount, 1) != burnAmount)
+            throw runtime_error("No non-fungible token input found for your pubkey\n");
+
+        // destination vouts (payouts) which would create the import tx with non-fungible token:
+        mtx.vout.push_back(MakeCC1vout(EVAL_TOKENS, txfee, GetUnspendable(cpTokens, NULL)));  // new marker to token cc addr, burnable and validated, vout position now changed to 0 (from 1)
+        mtx.vout.push_back(MakeTokensCC1vout(destEvalCode, burnAmount, destPubKey));
+        mtx.vout.push_back(CTxOut((CAmount)0, EncodeTokenCreateOpRet('c', vorigpubkey, name, description, 
+            std::vector<std::pair<uint8_t, vscript_t>> {std::make_pair(OPRETID_NONFUNGIBLEDATA, vopretNonfungible)})));  // make token import opret
+        ret.push_back(Pair("payouts", HexStr(E_MARSHAL(ss << mtx.vout))));  // save payouts for import tx
+
+        rawproof = E_MARSHAL(ss << chainSymbol << tokenbasetx); // add src chain name and token creation tx
+
+        CTxOut burnOut = MakeBurnOutput(0, ccid, targetSymbol, mtx.vout, rawproof);  //make opret with amount=0 because tokens are burned, not coins (see next vout) 
+
+        mtx.vout.clear();  // remove payouts
+        mtx.vout.push_back(MakeTokensCC1vout(destEvalCode, burnAmount, pubkey2pk(ParseHex(CC_BURNPUBKEY))));    // burn tokens
+                                                                                                                
+        int64_t change = inputs - txfee;
+        if (change != 0)
+            mtx.vout.push_back(CTxOut(change, CScript() << ParseHex(HexStr(myPubKey)) << OP_CHECKSIG));         // make change here to prevent it from making in FinalizeCCtx
+
+        std::vector<CPubKey> voutTokenPubkeys;
+        voutTokenPubkeys.push_back(pubkey2pk(ParseHex(CC_BURNPUBKEY)));  // maybe we do not need this because ccTokens has the const for burn pubkey
+
+        GetOpReturnData(burnOut.scriptPubKey, vopretBurnData);
+        mtx.vout.push_back(CTxOut(0, EncodeTokenOpRet(tokenid, voutTokenPubkeys, std::make_pair(OPRETID_BURNDATA, vopretBurnData))));  //opret
     }
 
-    ret.push_back(Pair("payouts", HexStr(E_MARSHAL(ss << mtx.vout))));  // save 'model' vout
-
-    const std::string chainSymbol(ASSETCHAINS_SYMBOL);
-    std::vector<uint8_t> rawproof(chainSymbol.begin(), chainSymbol.end());
-    //make opret with burned amount:
-    CTxOut burnOut = MakeBurnOutput(burnAmount, ccid, targetSymbol, mtx.vout, rawproof);
-
-    mtx.vout.clear();               // remove 'model' vout
-
-    int64_t change = inputs - (burnAmount + txfee);
-    if (change != 0)
-        mtx.vout.push_back(CTxOut(change, CScript() << ParseHex(HexStr(myPubKey)) << OP_CHECKSIG));
-
-    mtx.vout.push_back(burnOut);    // mtx now has only burned vout (that is, amount sent to OP_RETURN)
-
-    std::string exportTxHex = FinalizeCCTx(0, cpDummy, mtx, myPubKey, txfee, CScript()/*no opret*/);
-    ret.push_back(Pair("hex", HexStr(E_MARSHAL(ss << mtx))));
-
+    std::string burnTxHex = FinalizeCCTx(0, cpTokens, mtx, myPubKey, txfee, CScript()); //no change, no opret
+    ret.push_back(Pair("BurnTxHex", burnTxHex));
     return ret;
 }
 
-
 // util func to check burn tx and source chain params
-void CheckBurnTxSource(uint256 burntxid, std::string &targetSymbol, uint32_t &targetCCid) {
+void CheckBurnTxSource(uint256 burntxid, UniValue &info) {
 
     CTransaction burnTx;
     uint256 blockHash;
+
     if (!GetTransaction(burntxid, burnTx, blockHash, true))
-        throw std::runtime_error("cannot find burn transaction");
+        throw std::runtime_error("Cannot find burn transaction");
 
     if (blockHash.IsNull())
-        throw std::runtime_error("burn tx still in mempool");
+        throw std::runtime_error("Burn tx still in mempool");
 
     uint256 payoutsHash;
-    std::vector<uint8_t>rawproof;
+    std::string targetSymbol;
+    uint32_t targetCCid;
+    std::vector<uint8_t> rawproof;
 
     if (!UnmarshalBurnTx(burnTx, targetSymbol, &targetCCid, payoutsHash, rawproof))
-        throw std::runtime_error("cannot unmarshal burn tx data");
+        throw std::runtime_error("Cannot unmarshal burn tx data");
+
+    vscript_t vopret;
+    std::string sourceSymbol;
+    CTransaction tokenbasetx;
+    uint256 tokenid = zeroid;
+
+    if (burnTx.vout.size() > 1 && GetOpReturnData(burnTx.vout.back().scriptPubKey, vopret) && !vopret.empty())   {
+        if (vopret.begin()[0] == EVAL_TOKENS) {
+            if (!E_UNMARSHAL(rawproof, ss >> sourceSymbol; ss >> tokenbasetx))
+                throw std::runtime_error("Cannot unmarshal rawproof for tokens");
+
+            uint8_t evalCode;
+            uint256 tokenid;
+            std::vector<CPubKey> voutPubkeys;
+            std::vector<std::pair<uint8_t, vscript_t>> oprets;
+            if( DecodeTokenOpRet(burnTx.vout.back().scriptPubKey, evalCode, tokenid, voutPubkeys, oprets) == 0 )
+                throw std::runtime_error("Cannot decode token opret in burn tx");
+
+            if( tokenid != tokenbasetx.GetHash() )
+                throw std::runtime_error("Incorrect tokenbase tx");
+        }
+        else {
+            if (!E_UNMARSHAL(rawproof, ss >> sourceSymbol))
+                throw std::runtime_error("Cannot unmarshal rawproof for coins");
+        }
+    }
+    else {
+        throw std::runtime_error("No opret in burn tx");
+    }
+
+    if (sourceSymbol != ASSETCHAINS_SYMBOL)
+        throw std::runtime_error("Incorrect source chain in rawproof");
 
     if (targetCCid != ASSETCHAINS_CC)
-        throw std::runtime_error("incorrect CCid in burn tx");
+        throw std::runtime_error("Incorrect CCid in burn tx");
 
     if (targetSymbol == ASSETCHAINS_SYMBOL)
         throw std::runtime_error("Must not be called on the destination chain");
+
+    // fill info to return for the notary operator (if manual notarization) or user
+    info.push_back(Pair("SourceSymbol", sourceSymbol));
+    info.push_back(Pair("TargetSymbol", targetSymbol));
+    info.push_back(Pair("TargetCCid", std::to_string(targetCCid)));
+    if (!tokenid.IsNull())
+        info.push_back(Pair("tokenid", tokenid.GetHex()));
+
 }
 
 /*
- * The process to migrate funds
+ * The process to migrate funds from a chain to chain
  *
- * Create a transaction on assetchain:
+ * 1.Create a transaction on assetchain (deprecated):
+ * 1.1 generaterawtransaction
+ * 1.2 migrate_converttoexport
+ * 1.3 fundrawtransaction
+ * 1.4 signrawtransaction
  *
- * generaterawtransaction
- * migrate_converttoexport
- * fundrawtransaction
- * signrawtransaction
+ * alternatively, burn (export) transaction may be created with this new rpc call:
+ * 1. migrate_createburntransaction
  *
- * migrate_createimportransaction
- * migrate_completeimporttransaction
+ * next steps:
+ * 2. migrate_createimporttransaction
+ * 3. migrate_completeimporttransaction
  */
 
 UniValue migrate_createimporttransaction(const UniValue& params, bool fHelp)
@@ -406,19 +513,25 @@ UniValue migrate_createimporttransaction(const UniValue& params, bool fHelp)
     if (!E_UNMARSHAL(txData, ss >> burnTx))
         throw runtime_error("Couldn't parse burnTx");
 
+    if( burnTx.vin.size() == 0 )
+        throw runtime_error("No vins in the burnTx");
+
+    if (burnTx.vout.size() == 0)
+        throw runtime_error("No vouts in the burnTx");
+
+
     vector<CTxOut> payouts;
     if (!E_UNMARSHAL(ParseHexV(params[1], "argument 2"), ss >> payouts))
         throw runtime_error("Couldn't parse payouts");
 
     ImportProof importProof;
-    if (params.size() == 2) {
+    if (params.size() == 2) {  // standard MoMoM based notarization
         // get MoM import proof
         importProof = ImportProof(GetAssetchainProof(burnTx.GetHash(), burnTx));
     }
-    else   {
-        std::string targetSymbol;
-        uint32_t targetCCid;
-        CheckBurnTxSource(burnTx.GetHash(), targetSymbol, targetCCid);
+    else   {  // notarization by manual operators notary tx
+        UniValue info(UniValue::VOBJ);
+        CheckBurnTxSource(burnTx.GetHash(), info);
 
         // get notary import proof
         std::vector<uint256> notaryTxids;
@@ -433,13 +546,16 @@ UniValue migrate_createimporttransaction(const UniValue& params, bool fHelp)
 
     CTransaction importTx = MakeImportCoinTransaction(importProof, burnTx, payouts);
 
-    return HexStr(E_MARSHAL(ss << importTx));
+    std::string importTxHex = HexStr(E_MARSHAL(ss << importTx));
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("ImportTxHex", importTxHex));
+    return ret;
 }
 
 UniValue migrate_completeimporttransaction(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error("migrate_completeimporttransaction importTx offset\n\n"
+        throw runtime_error("migrate_completeimporttransaction importTx [offset]\n\n"
                 "Takes a cross chain import tx with proof generated on assetchain "
                 "and extends proof to target chain proof root\n"
                 "offset is optional, use it to increase the used KMD height, use when import fails.");
@@ -457,7 +573,10 @@ UniValue migrate_completeimporttransaction(const UniValue& params, bool fHelp)
 
     CompleteImportTransaction(importTx, offset);
 
-    return HexStr(E_MARSHAL(ss << importTx));
+    std::string importTxHex = HexStr(E_MARSHAL(ss << importTx));
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("ImportTxHex", importTxHex));
+    return ret;
 }
 
 /*
@@ -485,20 +604,16 @@ UniValue migrate_checkburntransactionsource(const UniValue& params, bool fHelp)
         throw runtime_error("Must be called on asset chain");
 
     uint256 burntxid = Parseuint256(params[0].get_str().c_str());
-    std::string targetSymbol;
-    uint32_t targetCCid;
-    CheckBurnTxSource(burntxid, targetSymbol, targetCCid);
+    UniValue result(UniValue::VOBJ);
+    CheckBurnTxSource(burntxid, result);  // check and get burn tx data
 
     // get tx proof for burn tx
     UniValue nextparams(UniValue::VARR);
     UniValue txids(UniValue::VARR);
     txids.push_back(burntxid.GetHex());
     nextparams.push_back(txids);
+    result.push_back(Pair("TxOutProof", gettxoutproof(nextparams, false)));  // get txoutproof
 
-    UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("TargetSymbol", targetSymbol));
-    result.push_back(Pair("TargetCCid", std::to_string(targetCCid)));
-    result.push_back(Pair("TxOutProof", gettxoutproof(nextparams, false)));
     return result;
 }
 
@@ -514,12 +629,6 @@ UniValue migrate_createnotaryapprovaltransaction(const UniValue& params, bool fH
 
     if (ASSETCHAINS_SYMBOL[0] == 0)
         throw runtime_error("Must be called on asset chain");
-
-    /*string srcSymbol = params[0].get_str();
-    if (srcSymbol.size() == 0 || srcSymbol.size() > 32)
-        throw runtime_error("srcchain length must be >0 and <=32");
-    if (strcmp(ASSETCHAINS_SYMBOL, srcSymbol.c_str()) == 0)
-        throw runtime_error("cant send a coin to the same chain");*/
 
     uint256 burntxid = Parseuint256(params[0].get_str().c_str());
     if (burntxid.IsNull())
@@ -541,14 +650,15 @@ UniValue migrate_createnotaryapprovaltransaction(const UniValue& params, bool fH
 
     // creating a tx with proof:
     CMutableTransaction mtx = CreateNewContextualCMutableTransaction(Params().GetConsensus(), komodo_nextheight());
-    int64_t inputs;
-    if ((inputs = AddNormalinputs(mtx, Mypubkey(), txfee*2, 4)) == 0) {
+    if (AddNormalinputs(mtx, Mypubkey(), txfee*2, 4) == 0) 
         throw runtime_error("Cannot find normal inputs\n");
-    }
-
+    
     mtx.vout.push_back(CTxOut(txfee, CScript() << ParseHex(HexStr(Mypubkey())) << OP_CHECKSIG));
+    std::string notaryTxHex = FinalizeCCTx(0, cpDummy, mtx, Mypubkey(), txfee, CScript() << OP_RETURN << E_MARSHAL(ss << proofData;));
 
-    return FinalizeCCTx(0, cpDummy, mtx, Mypubkey(), txfee, CScript() << OP_RETURN << E_MARSHAL(ss /*<< srcSymbol << revuint256(burntxid)*/ << proofData;));
+    UniValue result(UniValue::VOBJ);
+    result.push_back(Pair("NotaryTxHex", notaryTxHex));
+    return result;
 }
 
 // creates a source 'quasi-burn' tx for AC_PUBKEY
@@ -789,7 +899,8 @@ UniValue getimports(const UniValue& params, bool fHelp)
             {
                 objTx.push_back(Pair("address", CBitcoinAddress(importaddress).ToString()));
             }
-            UniValue objBurnTx(UniValue::VOBJ);            
+            UniValue objBurnTx(UniValue::VOBJ);      
+            CPubKey vinPubkey;
             if (UnmarshalImportTx(tx, proof, burnTx, payouts)) 
             {
                 if (burnTx.vout.size() == 0)
@@ -802,8 +913,14 @@ UniValue getimports(const UniValue& params, bool fHelp)
                 {
                     if (rawproof.size() > 0)
                     {
-                        std::string sourceSymbol(rawproof.begin(), rawproof.end());
+                        std::string sourceSymbol;
+                        CTransaction tokenbasetx;
+                        E_UNMARSHAL(rawproof,   ss >> sourceSymbol; 
+                                                if (!ss.eof())
+                                                    ss >> tokenbasetx );
                         objBurnTx.push_back(Pair("source", sourceSymbol));
+                        if( !tokenbasetx.IsNull() )
+                            objBurnTx.push_back(Pair("tokenid", tokenbasetx.GetHash().GetHex()));
                     }
                 }
             }
@@ -815,4 +932,136 @@ UniValue getimports(const UniValue& params, bool fHelp)
     result.push_back(Pair("TotalImported", TotalImported > 0 ? ValueFromAmount(TotalImported) : 0 ));    
     result.push_back(Pair("time", block.GetBlockTime()));
     return result;
+}
+
+// outputs burn transactions in the wallet 
+UniValue getwalletburntransactions(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error(
+            "getwalletburntransactions \"count\"\n\n"
+            "Lists most recent wallet burn transactions up to \'count\' parameter\n"
+            "parameter \'count\' is optional. If omitted, defaults to 10 burn transactions"
+            "\n\n"
+            "\nResult:\n"
+            "[\n"
+            "    {\n"
+            "       \"txid\": (string)\n"
+            "       \"burnedAmount\" : (numeric)\n"
+            "       \"targetSymbol\" : (string)\n"
+            "       \"targetCCid\" : (numeric)\n"
+            "    }\n"
+            "]\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getwalletburntransactions", "100")
+            + HelpExampleRpc("getwalletburntransactions", "100")
+            + HelpExampleCli("getwalletburntransactions", "")
+            + HelpExampleRpc("getwalletburntransactions", "")
+        );
+
+    if (!EnsureWalletIsAvailable(fHelp))
+        return NullUniValue;
+
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    string strAccount = "*";
+    isminefilter filter = ISMINE_SPENDABLE;
+    int nCount = 10;
+
+    if (params.size() == 1)
+        nCount = atoi(params[0].get_str());
+    if (nCount < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
+
+    UniValue ret(UniValue::VARR);
+
+    std::list<CAccountingEntry> acentries;
+    CWallet::TxItems txOrdered = pwalletMain->OrderedTxItems(acentries, strAccount);
+
+    // iterate backwards until we have nCount items to return:
+    for (CWallet::TxItems::reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
+    {
+        CWalletTx *const pwtx = (*it).second.first;
+        if (pwtx != 0)
+        {
+            LOGSTREAM("importcoin", CCLOG_DEBUG2, stream << "pwtx iterpos=" << (int32_t)pwtx->nOrderPos << " txid=" << pwtx->GetHash().GetHex() << std::endl);
+            vscript_t vopret;
+            std::string targetSymbol;
+            uint32_t targetCCid; uint256 payoutsHash;
+            std::vector<uint8_t> rawproof;
+            bool isNewBurnTx = false;
+
+            if (pwtx->vout.size() > 0 && GetOpReturnData(pwtx->vout.back().scriptPubKey, vopret) && !vopret.empty() &&
+                (isNewBurnTx = UnmarshalBurnTx(*pwtx, targetSymbol, &targetCCid, payoutsHash, rawproof)) || UnmarshalBurnTxOld(*pwtx, targetSymbol, &targetCCid, payoutsHash, rawproof)) {
+                UniValue entry(UniValue::VOBJ);
+                entry.push_back(Pair("txid", pwtx->GetHash().GetHex()));
+                if (isNewBurnTx && vopret.begin()[0] == EVAL_TOKENS) {
+                    // get burned token value
+                    std::vector<std::pair<uint8_t, vscript_t>>  oprets;
+                    uint256 tokenid;
+                    uint8_t evalCodeInOpret;
+                    std::vector<CPubKey> voutTokenPubkeys;
+
+                    //skip token opret:
+                    if (DecodeTokenOpRet(pwtx->vout.back().scriptPubKey, evalCodeInOpret, tokenid, voutTokenPubkeys, oprets) != 0) {
+                        CTransaction tokenbasetx;
+                        uint256 hashBlock;
+
+                        if (myGetTransaction(tokenid, tokenbasetx, hashBlock)) {
+                            std::vector<uint8_t> vorigpubkey;
+                            std::string name, description;
+                            std::vector<std::pair<uint8_t, vscript_t>>  oprets;
+                            vscript_t vopretNonfungible;
+
+                            if (tokenbasetx.vout.size() > 0 &&
+                                DecodeTokenCreateOpRet(tokenbasetx.vout.back().scriptPubKey, vorigpubkey, name, description, oprets) == 'c' &&
+                                GetOpretBlob(oprets, OPRETID_NONFUNGIBLEDATA, vopretNonfungible))
+                            {
+                                uint8_t destEvalCode = vopretNonfungible.begin()[0];
+                                int64_t burnAmount = 0;
+
+                                for (auto v : pwtx->vout)
+                                    if (v.scriptPubKey.IsPayToCryptoCondition() &&
+                                        CTxOut(v.nValue, v.scriptPubKey) == MakeTokensCC1vout(destEvalCode ? destEvalCode : EVAL_TOKENS, v.nValue, pubkey2pk(ParseHex(CC_BURNPUBKEY))))  // burned to dead pubkey
+                                        burnAmount += v.nValue;
+
+                                entry.push_back(Pair("burnedAmount", ValueFromAmount(burnAmount)));
+                                entry.push_back(Pair("tokenid", tokenid.GetHex()));
+                            }
+                        }
+                    }
+                }
+                else 
+                    entry.push_back(Pair("burnedAmount", ValueFromAmount(pwtx->vout.back().nValue)));   // coins
+                entry.push_back(Pair("targetSymbol", targetSymbol));
+                entry.push_back(Pair("targetCCid", std::to_string(targetCCid)));
+                if (mytxid_inmempool(pwtx->GetHash()))
+                    entry.push_back(Pair("inMempool", "yes"));
+                ret.push_back(entry);
+            }
+        } //else fprintf(stderr,"null pwtx\n
+        if ((int)ret.size() >= (nCount))
+            break;
+    }
+    // ret is newest to oldest
+
+    if (nCount > (int)ret.size())
+        nCount = ret.size();
+
+    vector<UniValue> arrTmp = ret.getValues();
+
+    vector<UniValue>::iterator first = arrTmp.begin();
+    vector<UniValue>::iterator last = arrTmp.begin();
+    std::advance(last, nCount);
+
+    if (last != arrTmp.end()) arrTmp.erase(last, arrTmp.end());
+    if (first != arrTmp.begin()) arrTmp.erase(arrTmp.begin(), first);
+
+    std::reverse(arrTmp.begin(), arrTmp.end()); // Return oldest to newest
+
+    ret.clear();
+    ret.setArray();
+    ret.push_backV(arrTmp);
+
+    return ret;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -350,6 +350,7 @@ static const CRPCCommand vRPCCommands[] =
     { "crosschain",         "getNotarisationsForBlock", &getNotarisationsForBlock, true },
     { "crosschain",         "scanNotarisationsDB",    &scanNotarisationsDB,    true },
     { "crosschain",         "getimports",             &getimports,             true },
+    { "crosschain",         "getwalletburntransactions",  &getwalletburntransactions,             true },
     { "crosschain",         "migrate_converttoexport", &migrate_converttoexport, true  },
     { "crosschain",         "migrate_createburntransaction", &migrate_createburntransaction, true },
     { "crosschain",         "migrate_createimporttransaction", &migrate_createimporttransaction, true  },
@@ -551,6 +552,7 @@ static const CRPCCommand vRPCCommands[] =
 	{ "hidden",             "test_heirmarker",        &test_heirmarker,    true }, 
 	{ "hidden",             "test_proof",        &test_proof,    true },
     { "hidden",             "test_burntx",            &test_burntx,    true },
+    { "hidden",             "test_tokencreate",            &test_tokencreate,    true },
 
 
 #ifdef ENABLE_WALLET

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -465,6 +465,7 @@ extern UniValue crosschainproof(const UniValue& params, bool fHelp);
 extern UniValue getNotarisationsForBlock(const UniValue& params, bool fHelp);
 extern UniValue scanNotarisationsDB(const UniValue& params, bool fHelp);
 extern UniValue getimports(const UniValue& params, bool fHelp);
+extern UniValue getwalletburntransactions(const UniValue& params, bool fHelp);
 extern UniValue migrate_converttoexport(const UniValue& params, bool fHelp);
 extern UniValue migrate_createburntransaction(const UniValue& params, bool fHelp);
 extern UniValue migrate_createimporttransaction(const UniValue& params, bool fHelp);
@@ -487,5 +488,6 @@ extern UniValue test_ac(const UniValue& params, bool fHelp);
 extern UniValue test_heirmarker(const UniValue& params, bool fHelp);
 extern UniValue test_burntx(const UniValue& params, bool fHelp);
 extern UniValue test_proof(const UniValue& params, bool fHelp);
+extern UniValue test_tokencreate(const UniValue& params, bool fHelp);
 
 #endif // BITCOIN_RPCSERVER_H


### PR DESCRIPTION
Fix changes summary:
- added token support to migration rpc (allows tokenid in migrate_createburntransaction rpc)
- added validation of token originator pubkey
- added tokenbase tx to burn tx and its validation
Note: import tx format changed to support tokens in opret (however, this fix is compatible with and validates the current import tx format for transactions on CFEKDIMXY chain)
